### PR TITLE
ci(Workflows): add a condition to trigger versioning workflow [skip ci] [skip hint]

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -7,6 +7,9 @@ on:
   
 jobs:
   build:
+    if: github.repository == 'serverlessworkflow/synapse' && github.ref_name == 'main'
+#   Check the current repository of performing the action, if it is not the 'serverlessworkflow/synapse' cancels the job.
+#   Check the current branch of performing the action, if it is not the 'main' cancel the job.
     runs-on: ubuntu-18.04
 
     steps:
@@ -17,8 +20,10 @@ jobs:
 
       - name: Reset Origin
         run: |
-          git remote set-url origin "https://cdavernas:${{ secrets.GITHUB_TOKEN }}@github.com/serverlessworkflow/synapse.git"
+          git remote set-url origin "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
           git checkout ${{ github.ref_name }}
+#   'github.actor' will be the account how will perform the push (or most of the case 'merge pull request').
+#   'secrets.GITHUB_TOKEN' was the token creates for the current action, it is associated with the 'github.actor' and will persist until the end of the action.
           
       - name: Install Versioning.NET
         run: |


### PR DESCRIPTION
**Many thanks for submitting your Pull Request :heart:!**

**What this PR does / why we need it**:
This PR adds a condition to trigger versioning workflows, to prevent useless versioning.
Whit auto-versioning the change of version must only be done in the primary repository (aka `serverlessworkflow/synapse`).

**Special notes for reviewers**:
Add also `github.actor` and `github.repository` variable to the origin url.